### PR TITLE
markdown syntax fix on coveant link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -64,7 +64,7 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][https://www.contributor-covenant.org],
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
 version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 For answers to common questions about this code of conduct, see


### PR DESCRIPTION
Markdown format fix

Hello -- while reading your code of conduct I noticed that you appeared to  use Markdown linking syntax but used square brackets around the target url rather than parenthesis. Note, I am using github.dev for the first time with this PR, so please pardon any anomalies with this PR, feeback always welcome. 