### PR TITLE
Basic guideline and template for github issue creations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,21 @@ If you have any other questions about contributing, please ask them on this
 We strive to keep the Ockam community an open and welcoming environment.
 Please read and follow our [Community Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Creating Issues
+
+### Bugs
+Template for a bug creation can be found [here](templates/BUG.md).
+
+General gudlines:
+* Describe the current state, compared to the  desired state
+* Provide exact links of code to change
+* Provide steps to produce
+* Be sure to label the issue with approriate labels where applicable (e.g. "Good First Issue", "Help Wanted")
+
+### Features
+Template for feature creation can be found [here](templates/FEATURE.md).
+
+
 ## Get help
 
 If you have any questions or need help integrating Ockam into your application

--- a/templates/BUG.md
+++ b/templates/BUG.md
@@ -1,0 +1,23 @@
+<!--- Provide a general summary of the issue in the Title above -->
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+---
+<!-- Only include this footer, for issues that are approriate for first time and help wanted -->
+_We love helping new contributors!_
+_If you have questions or need help as you work on your first Ockam contribution, please leave a comment on [this discussion](https://github.com/ockam-network/ockam/discussions/1081)._
+_If you're looking for other issues to contribute to, checkout [this discussion](https://github.com/build-trust/ockam/discussions/3206) and labels -  https://github.com/build-trust/ockam/labels/good%20first%20issue or https://github.com/build-trust/ockam/labels/help%20wanted_

--- a/templates/FEATURE.md
+++ b/templates/FEATURE.md
@@ -1,0 +1,17 @@
+<!--- Provide a general summary of the feature in the Title above -->
+## Summary
+<!-- Provide a brief explanation of the feature -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Basic Example
+<!-- Tell us a basic usage example -->
+
+## Unresolved Questions
+<!-- What questions, if any, remain unresolved  -->
+
+<!-- Only include this footer, for issues that are approriate for first time and help wanted -->
+_We love helping new contributors!_
+_If you have questions or need help as you work on your first Ockam contribution, please leave a comment on [this discussion](https://github.com/ockam-network/ockam/discussions/1081)._
+_If you're looking for other issues to contribute to, checkout [this discussion](https://github.com/build-trust/ockam/discussions/3206) and labels -  https://github.com/build-trust/ockam/labels/good%20first%20issue or https://github.com/build-trust/ockam/labels/help%20wanted_


### PR DESCRIPTION
These are a basic template we can use.

Additionally updating the settings of the Ockam repository can allow for these templates to be default on creation.